### PR TITLE
Catch when sequences are different sizes

### DIFF
--- a/pairmapper.py
+++ b/pairmapper.py
@@ -198,6 +198,11 @@ class PairMapper(object):
 
         def isComplement(seq1, seq2, maxGU, maxNC):
             counts = [0,0,0]
+
+            # Not considered complementary if different lengths
+            if len(seq1) != len(seq2):
+                return False
+            
             for i in range(len(seq1)):
                 pair = seq1[i] + seq2[-(i+1)]
 


### PR DESCRIPTION
In computeComplementaryCorrs, slices can be different lengths if position j is within window size of the end of the sequence.  Add a check to isComplement to catch sequences of different sizes.  If the sizes of two sequences are different, return False.